### PR TITLE
fix: add favicon metadata for browser tab icon

### DIFF
--- a/src/app/(website)/layout.tsx
+++ b/src/app/(website)/layout.tsx
@@ -18,6 +18,9 @@ export const metadata: Metadata = {
   title: title,
   description: description,
   keywords: ['teater', 'Oslo', 'Lokaltheatret'],
+  icons: {
+    icon: '/assets/favicon.png',
+  },
   openGraph: {
     type: 'website',
     url: url,


### PR DESCRIPTION
The favicon was only referenced in openGraph and twitter metadata, which are for social media previews. Added the icons property so Next.js emits the proper <link rel="icon"> tag in the HTML head.