### PR TITLE
fix: use opacity-100 instead of opacity-1 for Tailwind CSS v4

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -19,7 +19,7 @@ const Hero = ({ data }: Props) => {
       <div className="absolute z-0 h-full w-full bg-black opacity-100" />
       {data.videoUrl && (
         <div
-          className={`absolute z-4 h-[50vh] max-h-[70vh] w-full transition-opacity duration-300 ease-in md:h-full ${videoEnded ? 'opacity-0' : 'opacity-1'}`}
+          className={`absolute z-4 h-[50vh] max-h-[70vh] w-full transition-opacity duration-300 ease-in md:h-full ${videoEnded ? 'opacity-0' : 'opacity-100'}`}
         >
           <video
             preload="auto"

--- a/src/components/Plays/ContributorsSection.tsx
+++ b/src/components/Plays/ContributorsSection.tsx
@@ -89,7 +89,7 @@ const ContributorsSection = ({
           </button>
         )}
         <div
-          className={`flex flex-col gap-y-8 transition-height-width-opacity-display delay-200 ease-in-out md:gap-y-16 ${isOpen ? 'h-full w-full opacity-1' : 'h-0 w-0 opacity-0'}`}
+          className={`flex flex-col gap-y-8 transition-height-width-opacity-display delay-200 ease-in-out md:gap-y-16 ${isOpen ? 'h-full w-full opacity-100' : 'h-0 w-0 opacity-0'}`}
         >
           <ContributorList contributorList={contributors.actors} />
           <ContributorList title="KUNSTNERISK LAG" contributorList={contributors.artisticTeam} />


### PR DESCRIPTION
In Tailwind CSS v4, opacity-1 resolves to opacity: 1% (nearly invisible), not opacity: 100%. This caused the Medvirkende section and hero video to appear empty/invisible when toggled or displayed.