### PR TITLE
feat: add prev/next navigation to fullscreen image modal

### DIFF
--- a/src/components/ImageGallery.tsx
+++ b/src/components/ImageGallery.tsx
@@ -12,7 +12,7 @@ import SanityImage from './SanityImage';
 
 const ImageGallery = ({ images }: { images: SanityImageType[] }) => {
   const scrollToRef = useRef<HTMLDivElement | null>(null);
-  const [chosenImg, setChosenImg] = useState<SanityImageType | undefined>(undefined);
+  const [chosenIndex, setChosenIndex] = useState<number | null>(null);
 
   const [numberOfPages, setNumberOfPages] = useState<number | undefined>();
   const [maxScrollRight, setMaxScrollRight] = useState(true);
@@ -133,7 +133,7 @@ const ImageGallery = ({ images }: { images: SanityImageType[] }) => {
           {images.map((image, index) => (
             <div
               key={'img-gallery-' + index}
-              onClick={() => setChosenImg(image)}
+              onClick={() => setChosenIndex(index)}
               className="max-h-[500px] w-[350px] shrink-0 cursor-pointer snap-start p-4"
             >
               <SanityImage
@@ -167,7 +167,14 @@ const ImageGallery = ({ images }: { images: SanityImageType[] }) => {
             />
           ))}
       </div>
-      {chosenImg && <ImageModal chosenImg={chosenImg} setChosenImg={setChosenImg} />}
+      {chosenIndex !== null && (
+        <ImageModal
+          images={images}
+          currentIndex={chosenIndex}
+          onChangeIndex={setChosenIndex}
+          onClose={() => setChosenIndex(null)}
+        />
+      )}
     </div>
   );
 };

--- a/src/components/ImageModal.tsx
+++ b/src/components/ImageModal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
+import { IoIosArrowBack, IoIosArrowForward } from 'react-icons/io';
 import { RxCross2 } from 'react-icons/rx';
 
 import { assertIsNode } from '@/lib/helpers';
@@ -9,28 +10,48 @@ import { SanityImage as SanityImageType } from '@/lib/types';
 import SanityImage from './SanityImage';
 
 const ImageModal = ({
-  chosenImg,
-  setChosenImg,
+  images,
+  currentIndex,
+  onChangeIndex,
+  onClose,
 }: {
-  chosenImg: SanityImageType;
-  setChosenImg: (img: SanityImageType | undefined) => void;
+  images: SanityImageType[];
+  currentIndex: number;
+  onChangeIndex: (index: number) => void;
+  onClose: () => void;
 }) => {
-  const refElement = useRef<HTMLImageElement | null>(null);
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  const chosenImg = images[currentIndex];
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       const { target } = event;
       assertIsNode(target);
-      if (refElement.current && !refElement.current.contains(target as Node)) {
-        setChosenImg(undefined);
+      if (contentRef.current && !contentRef.current.contains(target as Node)) {
+        onClose();
       }
     };
     document.addEventListener('mousedown', handleClickOutside);
     return () => {
-      // Cleanup: remove event listener on unmount
       document.removeEventListener('mousedown', handleClickOutside);
     };
-  }, [refElement, setChosenImg]);
+  }, [onClose]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      } else if (event.key === 'ArrowRight' && currentIndex < images.length - 1) {
+        onChangeIndex(currentIndex + 1);
+      } else if (event.key === 'ArrowLeft' && currentIndex > 0) {
+        onChangeIndex(currentIndex - 1);
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [currentIndex, images.length, onChangeIndex, onClose]);
 
   useEffect(() => {
     document.body.style.overflow = 'hidden';
@@ -49,30 +70,54 @@ const ImageModal = ({
       <div className="flex h-full w-full items-center justify-center gap-x-4 p-2 md:p-10">
         <button
           className="absolute top-5 right-5 rounded-full bg-black p-2"
-          onClick={() => setChosenImg(undefined)}
+          onClick={onClose}
         >
           <RxCross2 color="white" />
         </button>
 
-        <div ref={refElement} className="relative max-h-full max-w-full">
-          <SanityImage
-            className="max-h-[90vh] max-w-[90vw] object-contain"
-            src={chosenImg.image}
-            alt={chosenImg.altText}
-            width={1200}
-            height={800}
-            lqip={chosenImg.lqip}
-            sizes="90vw"
-          />
+        <div ref={contentRef} className="flex items-center gap-x-4">
+          <div className="w-10 shrink-0">
+            {currentIndex > 0 && (
+              <button
+                className="rounded-full bg-black p-2"
+                onClick={() => onChangeIndex(currentIndex - 1)}
+              >
+                <IoIosArrowBack color="white" size={20} />
+              </button>
+            )}
+          </div>
 
-          {chosenImg.caption && (
-            <p
-              className="absolute right-0 bottom-5 left-0 m-0 mx-auto max-w-[300px] p-2 text-white md:max-w-[500px]"
-              style={{ backgroundColor: 'rgba(0,0,0,0.8)' }}
-            >
-              {chosenImg.caption}
-            </p>
-          )}
+          <div className="relative max-h-full max-w-full">
+            <SanityImage
+              className="max-h-[90vh] max-w-[80vw] object-contain"
+              src={chosenImg.image}
+              alt={chosenImg.altText}
+              width={1200}
+              height={800}
+              lqip={chosenImg.lqip}
+              sizes="80vw"
+            />
+
+            {chosenImg.caption && (
+              <p
+                className="absolute right-0 bottom-5 left-0 m-0 mx-auto max-w-[300px] p-2 text-white md:max-w-[500px]"
+                style={{ backgroundColor: 'rgba(0,0,0,0.8)' }}
+              >
+                {chosenImg.caption}
+              </p>
+            )}
+          </div>
+
+          <div className="w-10 shrink-0">
+            {currentIndex < images.length - 1 && (
+              <button
+                className="rounded-full bg-black p-2"
+                onClick={() => onChangeIndex(currentIndex + 1)}
+              >
+                <IoIosArrowForward color="white" size={20} />
+              </button>
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/ImageModal.tsx
+++ b/src/components/ImageModal.tsx
@@ -75,27 +75,16 @@ const ImageModal = ({
           <RxCross2 color="white" />
         </button>
 
-        <div ref={contentRef} className="flex items-center gap-x-4">
-          <div className="w-10 shrink-0">
-            {currentIndex > 0 && (
-              <button
-                className="rounded-full bg-black p-2"
-                onClick={() => onChangeIndex(currentIndex - 1)}
-              >
-                <IoIosArrowBack color="white" size={20} />
-              </button>
-            )}
-          </div>
-
+        <div ref={contentRef} className="relative flex items-center">
           <div className="relative max-h-full max-w-full">
             <SanityImage
-              className="max-h-[90vh] max-w-[80vw] object-contain"
+              className="max-h-[90vh] max-w-[90vw] object-contain md:max-w-[80vw]"
               src={chosenImg.image}
               alt={chosenImg.altText}
               width={1200}
               height={800}
               lqip={chosenImg.lqip}
-              sizes="80vw"
+              sizes="(max-width: 768px) 90vw, 80vw"
             />
 
             {chosenImg.caption && (
@@ -108,16 +97,23 @@ const ImageModal = ({
             )}
           </div>
 
-          <div className="w-10 shrink-0">
-            {currentIndex < images.length - 1 && (
-              <button
-                className="rounded-full bg-black p-2"
-                onClick={() => onChangeIndex(currentIndex + 1)}
-              >
-                <IoIosArrowForward color="white" size={20} />
-              </button>
-            )}
-          </div>
+          {currentIndex > 0 && (
+            <button
+              className="absolute left-1 rounded-full bg-black/60 p-2 md:left-[-50px] md:bg-black"
+              onClick={() => onChangeIndex(currentIndex - 1)}
+            >
+              <IoIosArrowBack color="white" size={20} />
+            </button>
+          )}
+
+          {currentIndex < images.length - 1 && (
+            <button
+              className="absolute right-1 rounded-full bg-black/60 p-2 md:right-[-50px] md:bg-black"
+              onClick={() => onChangeIndex(currentIndex + 1)}
+            >
+              <IoIosArrowForward color="white" size={20} />
+            </button>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
Add arrow button and keyboard navigation (ArrowLeft/ArrowRight/Escape) to the image gallery modal so users can browse images without closing and reopening the modal.