### PR TITLE
fix: use non-www domain for metadataBase

### DIFF
--- a/src/app/(website)/layout.tsx
+++ b/src/app/(website)/layout.tsx
@@ -11,7 +11,7 @@ import { SanityLive } from '@/lib/sanity/live';
 
 const title = 'Lokaltheatret';
 const description = 'Teater i hjerte av Oslo';
-const url = 'https://www.lokaltheatret.no';
+const url = 'https://lokaltheatret.no';
 
 export const metadata: Metadata = {
   metadataBase: new URL(url),


### PR DESCRIPTION
www.lokaltheatret.no 301-redirects to lokaltheatret.no, which causes Facebook's crawler to reject the OG image URL.