### PR TITLE
fix: use canonical non-www URL for metadataBase

### DIFF
--- a/src/app/(website)/layout.tsx
+++ b/src/app/(website)/layout.tsx
@@ -31,10 +31,13 @@ export const metadata: Metadata = {
     url: url,
     title: title,
     description: description,
+    siteName: title,
+    locale: 'nb_NO',
     images: [
       {
         url: '/assets/lokaltheatret-black-logo-white-bg.png',
         alt: title,
+        type: 'image/png',
         width: 2250,
         height: 945,
       },

--- a/src/app/(website)/layout.tsx
+++ b/src/app/(website)/layout.tsx
@@ -11,7 +11,7 @@ import { SanityLive } from '@/lib/sanity/live';
 
 const title = 'Lokaltheatret';
 const description = 'Teater i hjerte av Oslo';
-const url = 'https://www.lokaltheatret.no';
+const url = 'https://lokaltheatret.no';
 
 export const metadata: Metadata = {
   metadataBase: new URL(url),


### PR DESCRIPTION
The www.lokaltheatret.no domain 301-redirects to lokaltheatret.no, so the metadataBase should use the canonical non-www URL to avoid redirect hops when crawlers resolve og:image URLs.