### PR TITLE
fix: reduce server response time and strengthen CSP

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -15,31 +15,6 @@ const nextConfig = {
       fullUrl: true,
     },
   },
-  async headers() {
-    return [
-      {
-        source: '/((?!studio).*)',
-        headers: [
-          {
-            key: 'Content-Security-Policy',
-            value: [
-              "default-src 'self'",
-              "script-src 'self' 'unsafe-inline' https://scripts.simpleanalyticscdn.com",
-              "style-src 'self' 'unsafe-inline'",
-              "img-src 'self' data: blob: https://cdn.sanity.io https://queue.simpleanalyticscdn.com",
-              "font-src 'self'",
-              "connect-src 'self' https://*.sanity.io https://*.apicdn.sanity.io https://simpleanalyticscdn.com",
-              "media-src 'self' https://*.sanity.io https://*.mux.com",
-              "frame-src 'none'",
-              "object-src 'none'",
-              "base-uri 'self'",
-              "form-action 'self'",
-            ].join('; '),
-          },
-        ],
-      },
-    ];
-  },
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "@sanity/orderable-document-list": "^1.4.2",
     "@sanity/vision": "^5.25.1",
     "@sanity/visual-editing": "^5.2.1",
-    "motion": "^12.0.6",
     "next": "^16.1.6",
     "next-sanity": "^12.1.0",
     "react": "^19.2.3",

--- a/src/app/(website)/layout.tsx
+++ b/src/app/(website)/layout.tsx
@@ -1,7 +1,7 @@
 import '../globals.css';
 
 import { Metadata } from 'next';
-import { draftMode } from 'next/headers';
+import { draftMode, headers } from 'next/headers';
 import Script from 'next/script';
 import { VisualEditing } from 'next-sanity/visual-editing';
 
@@ -58,6 +58,7 @@ export const metadata: Metadata = {
 
 export default async function WebsiteLayout({ children }: { children: React.ReactNode }) {
   const { isEnabled: isDraftMode } = await draftMode();
+  const nonce = (await headers()).get('x-nonce') ?? undefined;
 
   return (
     <html lang="nb">
@@ -75,6 +76,7 @@ export default async function WebsiteLayout({ children }: { children: React.Reac
         <Script
           src="https://scripts.simpleanalyticscdn.com/latest.js"
           strategy="lazyOnload"
+          nonce={nonce}
         />
         <noscript>
           {/* eslint-disable-next-line @next/next/no-img-element */}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -25,20 +25,20 @@ const Footer = async () => {
         <p className="text-sm group-hover:underline">{footer.slogan}</p>
       </Link>
       <div className="flex flex-col gap-y-4">
-        <div className="flex flex-row">
+        <div className="flex flex-row gap-x-1">
           {footer.facebook && (
-            <a href={footer.facebook} target="_blank" rel="noopener noreferrer" aria-label="Facebook">
-              <CiFacebook />
+            <a href={footer.facebook} target="_blank" rel="noopener noreferrer" aria-label="Facebook" className="flex h-12 w-12 items-center justify-center">
+              <CiFacebook size={24} />
             </a>
           )}
           {footer.twitter && (
-            <a href={footer.twitter} target="_blank" rel="noopener noreferrer" aria-label="Twitter">
-              <CiTwitter />
+            <a href={footer.twitter} target="_blank" rel="noopener noreferrer" aria-label="Twitter" className="flex h-12 w-12 items-center justify-center">
+              <CiTwitter size={24} />
             </a>
           )}
           {footer.instagram && (
-            <a href={footer.instagram} target="_blank" rel="noopener noreferrer" aria-label="Instagram">
-              <CiInstagram />
+            <a href={footer.instagram} target="_blank" rel="noopener noreferrer" aria-label="Instagram" className="flex h-12 w-12 items-center justify-center">
+              <CiInstagram size={24} />
             </a>
           )}
         </div>

--- a/src/components/Plays/PlayCard.tsx
+++ b/src/components/Plays/PlayCard.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { SanityImageAssetDocument } from '@sanity/client';
-import { motion } from 'motion/react';
 import Link from 'next/link';
 import { useState } from 'react';
 import { FaArrowRightLong } from 'react-icons/fa6';
@@ -38,12 +37,9 @@ const PlayCard = ({
       onMouseOver={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >
-      <motion.div
-        className="play-card-contents"
-        initial={{ opacity: 1 }}
-        animate={{
-          opacity: isHovered ? 0 : 1,
-        }}
+      <div
+        className="play-card-contents transition-opacity duration-300"
+        style={{ opacity: isHovered ? 0 : 1 }}
       >
         <div className="relative h-full w-full">
           <SanityImage
@@ -66,13 +62,10 @@ const PlayCard = ({
             <p className="text-center">{playPeriod}</p>
           </div>
         </div>
-      </motion.div>
-      <motion.div
-        className="play-card-contents"
-        initial={{ opacity: 0 }}
-        animate={{
-          opacity: isHovered ? 1 : 0,
-        }}
+      </div>
+      <div
+        className="play-card-contents transition-opacity duration-300"
+        style={{ opacity: isHovered ? 1 : 0 }}
       >
         <div className="relative h-full w-full">
           <div
@@ -101,7 +94,7 @@ const PlayCard = ({
             quality={70}
           />
         </div>
-      </motion.div>
+      </div>
     </Link>
   );
 };

--- a/src/lib/sanity/fetch.ts
+++ b/src/lib/sanity/fetch.ts
@@ -1,12 +1,20 @@
 'use server';
 
+import { draftMode } from 'next/headers';
 import { defineQuery } from 'next-sanity';
 
 import { client } from './client';
+import { sanityFetch as liveFetch } from './live';
 
 const REVALIDATE_SECONDS = 30;
 
 async function fetchSanityData(query: string): Promise<any> {
+  const { isEnabled } = await draftMode();
+
+  if (isEnabled) {
+    return liveFetch({ query }).then((r) => r.data);
+  }
+
   return client.fetch(query, {}, { next: { revalidate: REVALIDATE_SECONDS } });
 }
 

--- a/src/lib/sanity/fetch.ts
+++ b/src/lib/sanity/fetch.ts
@@ -2,12 +2,18 @@
 
 import { defineQuery } from 'next-sanity';
 
-import { sanityFetch } from './live';
+import { client } from './client';
+
+const REVALIDATE_SECONDS = 30;
+
+async function fetchSanityData(query: string): Promise<any> {
+  return client.fetch(query, {}, { next: { revalidate: REVALIDATE_SECONDS } });
+}
 
 export const getFooter = async () => {
   const footerQuery = defineQuery("*[_type=='footer'][0]{...}");
 
-  return sanityFetch({ query: footerQuery }).then((result) => result.data);
+  return fetchSanityData(footerQuery);
 };
 
 export const getPlays = async () => {
@@ -21,7 +27,7 @@ export const getPlays = async () => {
         }
     `);
 
-  return sanityFetch({ query: playsQuery }).then((result) => result.data);
+  return fetchSanityData(playsQuery);
 };
 
 export const getPlayMetadata = async (slug: string) => {
@@ -30,7 +36,7 @@ export const getPlayMetadata = async (slug: string) => {
         "bannerImg": {"image": playBannerImg, "altText": playBannerImg.alt}
     }`);
 
-  return sanityFetch({ query: playMetadataQuery }).then((result) => result.data);
+  return fetchSanityData(playMetadataQuery);
 };
 
 export const getHighlightedPlayDescription = async (playTitle: string) => {
@@ -40,9 +46,8 @@ export const getHighlightedPlayDescription = async (playTitle: string) => {
         }
     }`);
 
-  return sanityFetch({ query: highlightedPlayQuery }).then(
-    (result) => result.data?.highlightedPlays?.description,
-  );
+  const data = await fetchSanityData(highlightedPlayQuery);
+  return data?.highlightedPlays?.description;
 };
 
 export const getPlay = async (slug: string) => {
@@ -85,7 +90,7 @@ export const getPlay = async (slug: string) => {
         }
     }`);
 
-  return sanityFetch({ query: playQuery }).then((result) => result.data);
+  return fetchSanityData(playQuery);
 };
 
 export const getMainBanner = async () => {
@@ -103,7 +108,7 @@ export const getMainBanner = async () => {
     }
 }`);
 
-  return sanityFetch({ query: mainBannerQuery }).then((result) => result.data);
+  return fetchSanityData(mainBannerQuery);
 };
 
 export const getAboutPage = async () => {
@@ -168,7 +173,7 @@ export const getAboutPage = async () => {
         foundersList[]{name, role, "image": {"image": image, "width": image.asset->metadata.dimensions.width, "height": image.asset->metadata.dimensions.height, "lqip": image.asset->metadata.lqip}}
     }`);
 
-  return sanityFetch({ query: aboutQuery }).then((result) => result.data);
+  return fetchSanityData(aboutQuery);
 };
 
 export const getArticles = async () => {
@@ -185,7 +190,7 @@ export const getArticles = async () => {
     }
   `);
 
-  return sanityFetch({ query: articlesQuery }).then((result) => result.data);
+  return fetchSanityData(articlesQuery);
 };
 
 export const getArticle = async (slug: string) => {
@@ -227,7 +232,7 @@ export const getArticle = async (slug: string) => {
     "textColor": textColor.hex
   }`);
 
-  return sanityFetch({ query: articleQuery }).then((result) => result.data);
+  return fetchSanityData(articleQuery);
 };
 
 export const getJoinPage = async () => {
@@ -264,5 +269,5 @@ export const getJoinPage = async () => {
         }
     }`);
 
-  return sanityFetch({ query: joinQuery }).then((result) => result.data);
+  return fetchSanityData(joinQuery);
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,6 +2,12 @@ import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 
 export function middleware(request: NextRequest) {
+  const isDraftMode = request.cookies.has('__prerender_bypass');
+
+  if (isDraftMode) {
+    return NextResponse.next();
+  }
+
   const nonce = Buffer.from(crypto.randomUUID()).toString('base64');
 
   const cspHeader = [

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,34 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  const nonce = Buffer.from(crypto.randomUUID()).toString('base64');
+
+  const cspHeader = [
+    "default-src 'self'",
+    `script-src 'self' 'nonce-${nonce}' 'strict-dynamic' https://scripts.simpleanalyticscdn.com`,
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data: blob: https://cdn.sanity.io https://queue.simpleanalyticscdn.com",
+    "font-src 'self'",
+    "connect-src 'self' https://*.sanity.io https://*.apicdn.sanity.io https://simpleanalyticscdn.com",
+    "media-src 'self' https://*.sanity.io https://*.mux.com",
+    "frame-src 'none'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+  ].join('; ');
+
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set('x-nonce', nonce);
+
+  const response = NextResponse.next({ request: { headers: requestHeaders } });
+  response.headers.set('Content-Security-Policy', cspHeader);
+
+  return response;
+}
+
+export const config = {
+  matcher: [
+    { source: '/((?!studio|api|_next/static|_next/image|favicon\\.ico|assets/).*)', missing: [{ type: 'header', key: 'next-router-prefetch' }] },
+  ],
+};


### PR DESCRIPTION
Switch Sanity data fetching from defineLive's sanityFetch (2 API calls per query, no CDN) to direct client.fetch() with Sanity CDN and 30s ISR caching. Replace motion/framer-motion with CSS transitions in PlayCard. Add CSP middleware with per-request nonces replacing unsafe-inline. Fix footer social icon tap targets to meet 48x48px minimum.