### PR TITLE
fix: resolve CSP inline script violations blocking Next.js hydration

### DIFF
--- a/src/app/(website)/layout.tsx
+++ b/src/app/(website)/layout.tsx
@@ -1,7 +1,7 @@
 import '../globals.css';
 
 import { Metadata } from 'next';
-import { draftMode, headers } from 'next/headers';
+import { draftMode } from 'next/headers';
 import Script from 'next/script';
 import { VisualEditing } from 'next-sanity/visual-editing';
 
@@ -58,8 +58,6 @@ export const metadata: Metadata = {
 
 export default async function WebsiteLayout({ children }: { children: React.ReactNode }) {
   const { isEnabled: isDraftMode } = await draftMode();
-  const nonce = (await headers()).get('x-nonce') ?? undefined;
-
   return (
     <html lang="nb">
       <body>
@@ -76,7 +74,6 @@ export default async function WebsiteLayout({ children }: { children: React.Reac
         <Script
           src="https://scripts.simpleanalyticscdn.com/latest.js"
           strategy="lazyOnload"
-          nonce={nonce}
         />
         <noscript>
           {/* eslint-disable-next-line @next/next/no-img-element */}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -8,15 +8,13 @@ export function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
-  const nonce = Buffer.from(crypto.randomUUID()).toString('base64');
-
   const cspHeader = [
     "default-src 'self'",
-    `script-src 'self' 'nonce-${nonce}' 'strict-dynamic' https://scripts.simpleanalyticscdn.com`,
+    "script-src 'self' 'unsafe-inline' https://scripts.simpleanalyticscdn.com",
     "style-src 'self' 'unsafe-inline'",
     "img-src 'self' data: blob: https://cdn.sanity.io https://queue.simpleanalyticscdn.com",
     "font-src 'self'",
-    "connect-src 'self' https://*.sanity.io https://*.apicdn.sanity.io https://simpleanalyticscdn.com",
+    "connect-src 'self' https://*.sanity.io https://*.apicdn.sanity.io https://queue.simpleanalyticscdn.com https://simpleanalyticscdn.com",
     "media-src 'self' https://*.sanity.io https://*.mux.com",
     "frame-src 'none'",
     "object-src 'none'",
@@ -24,10 +22,7 @@ export function middleware(request: NextRequest) {
     "form-action 'self'",
   ].join('; ');
 
-  const requestHeaders = new Headers(request.headers);
-  requestHeaders.set('x-nonce', nonce);
-
-  const response = NextResponse.next({ request: { headers: requestHeaders } });
+  const response = NextResponse.next();
   response.headers.set('Content-Security-Policy', cspHeader);
 
   return response;


### PR DESCRIPTION
Next.js App Router injects inline scripts for React Flight data that the framework does not apply nonce attributes to. The previous CSP used strict-dynamic which ignores unsafe-inline and self, effectively blocking all scripts. Replace nonce + strict-dynamic with unsafe-inline, and add queue.simpleanalyticscdn.com to connect-src for analytics.