### PR TITLE
fix: restore Sanity live editing and resolve Next.js 16 deprecations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,14 +15,12 @@
         "@sanity/orderable-document-list": "^1.4.2",
         "@sanity/vision": "^5.25.1",
         "@sanity/visual-editing": "^5.2.1",
-        "motion": "^12.0.6",
         "next": "^16.1.6",
         "next-sanity": "^12.1.0",
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
         "react-icons": "^5.4.0",
         "sanity": "^5.25.1",
-        "sonner": "^2.0.6",
         "styled-components": "^6.4.1"
       },
       "devDependencies": {
@@ -17480,16 +17478,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/cyyynthia"
-      }
-    },
-    "node_modules/sonner": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
-      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
-        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map": {

--- a/src/app/(website)/layout.tsx
+++ b/src/app/(website)/layout.tsx
@@ -8,6 +8,7 @@ import { VisualEditing } from 'next-sanity/visual-editing';
 import Footer from '@/components/Footer';
 import Header from '@/components/Header';
 import { SanityLive } from '@/lib/sanity/live';
+import { refreshAction } from '@/lib/sanity/refreshAction';
 
 const title = 'Lokaltheatret';
 const description = 'Teater i hjerte av Oslo';
@@ -65,7 +66,7 @@ export default async function WebsiteLayout({ children }: { children: React.Reac
         {children}
         {isDraftMode && (
           <>
-            <SanityLive />
+            <SanityLive revalidateSyncTags={refreshAction} />
             <VisualEditing />
           </>
         )}

--- a/src/lib/sanity/refreshAction.ts
+++ b/src/lib/sanity/refreshAction.ts
@@ -1,0 +1,5 @@
+'use client';
+
+export async function refreshAction(): Promise<'refresh'> {
+  return 'refresh';
+}

--- a/src/lib/sanity/resolve.ts
+++ b/src/lib/sanity/resolve.ts
@@ -16,6 +16,14 @@ export const resolve = {
       route: '/forestillinger/:slug',
       filter: `_type == "play" && slug.current == $slug`,
     },
+    {
+      route: '/artikler',
+      filter: `_type == "article"`,
+    },
+    {
+      route: '/artikler/:slug',
+      filter: `_type == "article" && slug.current == $slug`,
+    },
   ]),
   // Locations Resolver API allows you to define where data is being used in your application. https://www.sanity.io/docs/presentation-resolver-api#8d8bca7bfcd7
   locations: {
@@ -66,6 +74,20 @@ export const resolve = {
           {
             title: doc?.name || 'Untitled',
             href: `/forestillinger/${doc?.slug}`,
+          },
+        ],
+      }),
+    }),
+    article: defineLocations({
+      select: {
+        title: 'title',
+        slug: 'slug.current',
+      },
+      resolve: (doc) => ({
+        locations: [
+          {
+            title: doc?.title || 'Untitled',
+            href: `/artikler/${doc?.slug}`,
           },
         ],
       }),

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,7 +1,7 @@
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   const isDraftMode = request.cookies.has('__prerender_bypass');
 
   if (isDraftMode) {


### PR DESCRIPTION
- Add refreshAction workaround for Next.js 16 + next-sanity v12 incompatibility that broke live draft previews in Sanity Presentation Tool
- Rename middleware.ts to proxy.ts per Next.js 16 convention
- Add missing article routes to Sanity resolve config for Presentation Tool