### PR TITLE
fix: enable draft content updates in Sanity Presentation Tool

### DIFF
--- a/src/app/(website)/layout.tsx
+++ b/src/app/(website)/layout.tsx
@@ -8,7 +8,6 @@ import { VisualEditing } from 'next-sanity/visual-editing';
 import Footer from '@/components/Footer';
 import Header from '@/components/Header';
 import { SanityLive } from '@/lib/sanity/live';
-import { refreshAction } from '@/lib/sanity/refreshAction';
 
 const title = 'Lokaltheatret';
 const description = 'Teater i hjerte av Oslo';
@@ -66,7 +65,7 @@ export default async function WebsiteLayout({ children }: { children: React.Reac
         {children}
         {isDraftMode && (
           <>
-            <SanityLive revalidateSyncTags={refreshAction} />
+            <SanityLive />
             <VisualEditing />
           </>
         )}

--- a/src/lib/sanity/live.ts
+++ b/src/lib/sanity/live.ts
@@ -11,4 +11,5 @@ if (!token) {
 export const { sanityFetch, SanityLive } = defineLive({
   client,
   serverToken: token,
+  browserToken: token,
 });

--- a/src/lib/sanity/refreshAction.ts
+++ b/src/lib/sanity/refreshAction.ts
@@ -1,5 +1,0 @@
-'use client';
-
-export async function refreshAction(): Promise<'refresh'> {
-  return 'refresh';
-}


### PR DESCRIPTION
Add browserToken to defineLive so SanityLive subscribes to draft events (includeDrafts: true). Without it, draft edits never triggered revalidation because VisualEditing assumed the loader handled mutations while SanityLive only listened for published changes.

Remove custom refreshAction that bypassed cache tag invalidation — the default revalidateSyncTags server action properly calls revalidateTag() to invalidate the Next.js Data Cache.