### PR TITLE
perf: speed up first load via longer revalidate + on-demand webhook

### DIFF
--- a/src/app/(website)/api/revalidate/route.ts
+++ b/src/app/(website)/api/revalidate/route.ts
@@ -1,0 +1,27 @@
+import { revalidateTag } from 'next/cache';
+import { NextRequest } from 'next/server';
+import { parseBody } from 'next-sanity/webhook';
+
+// ponytail: one tag for the whole site — any publish revalidates everything.
+// Fine at this scale; switch to per-_type tags only if rebuilds get expensive.
+export const POST = async (req: NextRequest) => {
+  const secret = process.env.SANITY_REVALIDATE_SECRET;
+
+  if (!secret) {
+    return new Response('Missing SANITY_REVALIDATE_SECRET', { status: 500 });
+  }
+
+  const { isValidSignature, body } = await parseBody<{ _type: string }>(req, secret);
+
+  if (!isValidSignature) {
+    return new Response('Invalid signature', { status: 401 });
+  }
+
+  if (!body?._type) {
+    return new Response('Bad request', { status: 400 });
+  }
+
+  revalidateTag('sanity', 'max');
+
+  return Response.json({ revalidated: true, now: Date.now() });
+};

--- a/src/lib/sanity/client.ts
+++ b/src/lib/sanity/client.ts
@@ -7,9 +7,6 @@ export const client = createClient({
   dataset: process.env.NEXT_PUBLIC_SANITY_DATASET,
   apiVersion: '2025-07-24',
   useCdn: true,
-  stega: {
-    studioUrl: process.env.NEXT_PUBLIC_SANITY_STUDIO_URL,
-  },
 });
 
 const urlBuilderFactory = createImageUrlBuilder(client);

--- a/src/lib/sanity/fetch.ts
+++ b/src/lib/sanity/fetch.ts
@@ -6,7 +6,9 @@ import { defineQuery } from 'next-sanity';
 import { client } from './client';
 import { sanityFetch as liveFetch } from './live';
 
-const REVALIDATE_SECONDS = 30;
+// Long revalidate window keeps the edge cache warm; publishes trigger
+// instant updates via the /api/revalidate webhook (revalidateTag('sanity')).
+const REVALIDATE_SECONDS = 3600;
 
 async function fetchSanityData(query: string): Promise<any> {
   const { isEnabled } = await draftMode();
@@ -15,7 +17,7 @@ async function fetchSanityData(query: string): Promise<any> {
     return liveFetch({ query }).then((r) => r.data);
   }
 
-  return client.fetch(query, {}, { next: { revalidate: REVALIDATE_SECONDS } });
+  return client.fetch(query, {}, { next: { revalidate: REVALIDATE_SECONDS, tags: ['sanity'] } });
 }
 
 export const getFooter = async () => {

--- a/src/lib/sanity/live.ts
+++ b/src/lib/sanity/live.ts
@@ -8,8 +8,11 @@ if (!token) {
   throw new Error('Missing SANITY_VIEWER_TOKEN');
 }
 
+// stega lives here (draft/visual-editing only) so public visitors don't pay for it.
 export const { sanityFetch, SanityLive } = defineLive({
-  client,
+  client: client.withConfig({
+    stega: { studioUrl: process.env.NEXT_PUBLIC_SANITY_STUDIO_URL },
+  }),
   serverToken: token,
   browserToken: token,
 });


### PR DESCRIPTION
## Summary
Fixes the slow first page load (cold edge-cache miss -> origin render, ~1.4–2.3s TTFB vs ~0.12s warm).

- **Bump ISR `revalidate` 30s -> 1h** so the Netlify edge cache stays warm and stops triggering frequent cold origin renders. This is the main fix.
- **Add `/api/revalidate` webhook** (signature-verified via `next-sanity/webhook`) so Sanity publishes update the site instantly through `revalidateTag('sanity', 'max')` instead of waiting out the revalidate window.
- **Move stega to the draft-only live client** so production visitors no longer download visual-editing encoding.

## Setup required before this works end-to-end
- [ ] Add Netlify env var `SANITY_REVALIDATE_SECRET` (random string)
- [ ] Add Sanity webhook: POST `https://lokaltheatret.no/api/revalidate`, same secret, trigger create/update/delete
- [ ] Sanity webhook filter to skip drafts/versions: `!(_id in path("drafts.**")) && !(_id in path("versions.**"))`

## Test plan
- [ ] After deploy, confirm warm TTFB stays low and content still updates within the revalidate window
- [ ] Publish a doc in Sanity and confirm the site reflects it within seconds (webhook path)
- [ ] Verify visual editing / image previews still render in the Studio Presentation tool (stega moved to live client)