### PR TITLE
perf: preconnect to Sanity image CDN for faster LCP

### DIFF
--- a/src/app/(website)/layout.tsx
+++ b/src/app/(website)/layout.tsx
@@ -60,6 +60,9 @@ export default async function WebsiteLayout({ children }: { children: React.Reac
   const { isEnabled: isDraftMode } = await draftMode();
   return (
     <html lang="nb">
+      <head>
+        <link rel="preconnect" href="https://cdn.sanity.io" />
+      </head>
       <body>
         <Header />
         {children}


### PR DESCRIPTION
## Summary
Adds a `<link rel="preconnect" href="https://cdn.sanity.io" />` to the site `<head>`.

The hero image (the LCP element) is served from `cdn.sanity.io`, a separate origin from the site. Without preconnect, the browser only starts the DNS/TCP/TLS handshake to that origin when it reaches the image — adding ~300–600ms on mobile (less on desktop) before the largest above-the-fold pixels can paint.

Preconnecting warms that connection up front, so the already-preloaded hero starts downloading immediately. Targets **LCP** and **Speed Index** (benefits all devices; most noticeable on throttled mobile).

No `crossOrigin` attribute on purpose — the hero loads as a non-CORS `<img>` via next/image, so a CORS preconnect would open a separate, unused connection.

## Test plan
- [ ] Confirm `<link rel="preconnect" href="https://cdn.sanity.io">` appears in the page head after deploy
- [ ] Run pagespeed.web.dev before/after; check LCP and Speed Index improve
- [ ] Verify hero image still renders normally