### PR TITLE
fix: add exit banner for sticky draft mode on production

### DIFF
--- a/src/app/(website)/layout.tsx
+++ b/src/app/(website)/layout.tsx
@@ -5,6 +5,7 @@ import { draftMode } from 'next/headers';
 import Script from 'next/script';
 import { VisualEditing } from 'next-sanity/visual-editing';
 
+import DraftModeBanner from '@/components/DraftModeBanner';
 import Footer from '@/components/Footer';
 import Header from '@/components/Header';
 import { SanityLive } from '@/lib/sanity/live';
@@ -70,6 +71,7 @@ export default async function WebsiteLayout({ children }: { children: React.Reac
           <>
             <SanityLive />
             <VisualEditing />
+            <DraftModeBanner />
           </>
         )}
         <Footer />

--- a/src/components/DraftModeBanner.tsx
+++ b/src/components/DraftModeBanner.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useTransition } from 'react';
+
+import { disableDraftMode } from '@/app/(website)/actions';
+
+export default function DraftModeBanner() {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+
+  const exit = () =>
+    startTransition(async () => {
+      await disableDraftMode();
+      router.refresh();
+    });
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        bottom: 16,
+        left: '50%',
+        transform: 'translateX(-50%)',
+        zIndex: 9999,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        padding: '8px 16px',
+        borderRadius: 9999,
+        background: '#000',
+        color: '#fff',
+        fontSize: 14,
+        boxShadow: '0 2px 8px rgba(0,0,0,0.3)',
+      }}
+    >
+      <span>Viser utkast (draft)</span>
+      <button
+        onClick={exit}
+        disabled={pending}
+        style={{
+          padding: '4px 12px',
+          borderRadius: 9999,
+          border: '1px solid #fff',
+          background: 'transparent',
+          color: '#fff',
+          cursor: 'pointer',
+        }}
+      >
+        {pending ? 'Avslutter…' : 'Avslutt'}
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- The Presentation tool's `previewUrl` targets the production domain, so opening the preview enables Next.js draft mode on the live site itself. The draft cookie then persisted in the editor's browser with no way to tell or to exit — so they kept seeing draft content while browsing lokaltheatret.no normally.
- Adds a `DraftModeBanner` client component, rendered only in draft mode, wired to the existing `disableDraftMode` action for one-click exit.
- Anonymous visitors are unaffected: the public fetch path is tokenless with the `published` perspective and cannot return drafts.

## Test plan
- [ ] Open Studio → Presentation, confirm the "Viser utkast" banner appears in the preview
- [ ] Click "Avslutt" and confirm draft mode is cleared and the page refreshes to published content
- [ ] Browse lokaltheatret.no in a clean/incognito session and confirm no banner and no draft content