### PR TITLE
fix: bypass CDN for live/draft reads so Presentation updates in real time

### DIFF
--- a/src/lib/sanity/live.ts
+++ b/src/lib/sanity/live.ts
@@ -11,6 +11,8 @@ if (!token) {
 // stega lives here (draft/visual-editing only) so public visitors don't pay for it.
 export const { sanityFetch, SanityLive } = defineLive({
   client: client.withConfig({
+    // Live/draft reads must bypass the CDN, otherwise Presentation shows stale drafts.
+    useCdn: false,
     stega: { studioUrl: process.env.NEXT_PUBLIC_SANITY_STUDIO_URL },
   }),
   serverToken: token,


### PR DESCRIPTION
## Summary
- The `defineLive` client inherited `useCdn: true` from the base client, so draft reads in the Sanity Presentation tool could be served stale from Sanity's edge cache — appearing as live edits "not updating frequently."
- Live/preview reads must run uncached (`useCdn: false`); the public published path keeps the CDN on for performance.
- This is the documented Sanity setup: CDN on for public reads, off for the live/preview client.

## Test plan
- [ ] Open the Sanity Presentation tool, edit a document, and confirm changes appear within ~1-2s.
- [ ] Verify the public site still serves cached (CDN) reads with the existing revalidate/webhook behavior unchanged.