### PR TITLE
perf: defer hero banner video for faster initial load

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -21,8 +21,9 @@ const Hero = ({ data }: Props) => {
         <div
           className={`absolute z-4 h-[50vh] max-h-[70vh] w-full transition-opacity duration-300 ease-in md:h-full ${videoEnded ? 'opacity-0' : 'opacity-100'}`}
         >
+          {/* ponytail: metadata not auto — let the priority banner image win LCP; video streams after */}
           <video
-            preload="auto"
+            preload="metadata"
             playsInline
             autoPlay
             muted

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -21,7 +21,6 @@ const Hero = ({ data }: Props) => {
         <div
           className={`absolute z-4 h-[50vh] max-h-[70vh] w-full transition-opacity duration-300 ease-in md:h-full ${videoEnded ? 'opacity-0' : 'opacity-100'}`}
         >
-          {/* ponytail: metadata not auto — let the priority banner image win LCP; video streams after */}
           <video
             preload="metadata"
             playsInline


### PR DESCRIPTION
## Summary
- The homepage Hero rendered `<video preload="auto" autoPlay>`, telling the browser to download the **entire** banner mp4 (served raw from `cdn.sanity.io`) on first paint. That competes with the `priority` banner image for bandwidth and slows perceived initial load.
- Switch to `preload="metadata"` so the LCP image loads first and the autoplay video streams in afterward. No behavior change once loaded — it still autoplays.

## Why
Part of investigating slow production first-load. This is the safe, isolated client-side win (LCP). The larger server-side win (public pages are fully dynamically rendered because `draftMode()` is read outside a cache scope) is tracked separately as a Cache Components migration.

## Test plan
- [ ] Load homepage on a throttled connection — banner image paints promptly; video still autoplays shortly after.
- [ ] Confirm no regression to the Sanity live/visual-editing preview (this change is client-only, unrelated to draft mode).